### PR TITLE
Use prepublishOnly instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "npm run compile && mocha --compilers js:babel-core/register  --reporter spec",
     "compile": "babel --presets es2015 -d lib/ src/",
-    "prepublish": "../oo7/prepublish.sh && npm run compile",
+    "prepublishOnly": "../oo7/prepublish.sh && npm run compile",
     "postpublish": "../oo7/postpublish.sh"
   },
   "repository": {


### PR DESCRIPTION
The package is unusable at the moment since the `prepublish` script is run with `npm install` and uses a script from `../oo7`

@see https://docs.npmjs.com/misc/scripts#prepublish-and-prepare